### PR TITLE
feat(release): add support for pushing packages to the release feed

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -99,3 +99,28 @@ jobs:
         run: dotnet run --project _atom/_atom.csproj PushToNuget --skip --headless
         env:
           nuget-push-api-key: ${{ secrets.NUGET_PUSH_API_KEY }}
+  
+  PushToRelease:
+    needs: [ PackResults ]
+    runs-on: ubuntu-latest
+    steps:
+      
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      
+      - name: Download DecSm.Results
+        uses: actions/download-artifact@v4
+        with:
+          name: DecSm.Results
+          path: "${{ github.workspace }}/.github/artifacts/DecSm.Results"
+      
+      - name: PushToRelease
+        id: PushToRelease
+        run: dotnet run --project _atom/_atom.csproj PushToRelease --skip --headless
+        env:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/_atom/Build.cs
+++ b/_atom/Build.cs
@@ -2,7 +2,13 @@
 
 [BuildDefinition]
 [GenerateEntryPoint]
-internal partial class Build : DefaultBuildDefinition, IGithubWorkflows, IGitVersion, IPackResults, ITestResults, IPushToNuget
+internal partial class Build : DefaultBuildDefinition,
+    IGithubWorkflows,
+    IGitVersion,
+    IPackResults,
+    ITestResults,
+    IPushToNuget,
+    IPushToRelease
 {
     public override IReadOnlyList<IWorkflowOption> DefaultWorkflowOptions =>
     [
@@ -26,6 +32,7 @@ internal partial class Build : DefaultBuildDefinition, IGithubWorkflows, IGitVer
                 Commands.PackResults,
                 Commands.TestResults,
                 Commands.PushToNuget.WithAddedOptions(WorkflowSecretInjection.Create(Params.NugetApiKey)),
+                Commands.PushToRelease.WithGithubTokenInjection(),
             ],
             WorkflowTypes = [Github.WorkflowType],
         },

--- a/_atom/Targets/IPushToRelease.cs
+++ b/_atom/Targets/IPushToRelease.cs
@@ -1,0 +1,22 @@
+﻿namespace Atom.Targets;
+
+[TargetDefinition]
+internal partial interface IPushToRelease : IGithubReleaseHelper
+{
+    Target PushToRelease =>
+        d => d
+            .WithDescription("Pushes the package to the release feed.")
+            .RequiresParam(Params.GithubToken)
+            .ConsumesArtifact(Commands.PackResults, IPackResults.ResultsProjectName)
+            .Executes(async () =>
+            {
+                if (Version.IsPreRelease)
+                {
+                    Logger.LogInformation("Skipping release push for pre-release version");
+
+                    return;
+                }
+
+                await UploadArtifactToRelease(IPackResults.ResultsProjectName);
+            });
+}


### PR DESCRIPTION
Introduced a new `IPushToRelease` target for handling package releases. Updated the build process to include `PushToRelease` as a workflow step. Modified `.github/workflows/Build.yml` to automate release uploads, with support for GitHub token injection and artifact management.

This ensures seamless deployment for release versions, while skipping pre-release versions as intended.